### PR TITLE
unindent some lines so that methods are properly over written

### DIFF
--- a/examples/master.py
+++ b/examples/master.py
@@ -218,30 +218,30 @@ class MasterApplication(opendnp3.IMasterApplication):
     def __init__(self):
         super(MasterApplication, self).__init__()
 
-        # Overridden method
-        def AssignClassDuringStartup(self):
-            _log.debug('In MasterApplication.AssignClassDuringStartup')
-            return False
+    # Overridden method
+    def AssignClassDuringStartup(self):
+        _log.debug('In MasterApplication.AssignClassDuringStartup')
+        return False
 
-        # Overridden method
-        def OnClose(self):
-            _log.debug('In MasterApplication.OnClose')
+    # Overridden method
+    def OnClose(self):
+        _log.debug('In MasterApplication.OnClose')
 
-        # Overridden method
-        def OnOpen(self):
-            _log.debug('In MasterApplication.OnOpen')
+    # Overridden method
+    def OnOpen(self):
+        _log.debug('In MasterApplication.OnOpen')
 
-        # Overridden method
-        def OnReceiveIIN(self, iin):
-            _log.debug('In MasterApplication.OnReceiveIIN')
+    # Overridden method
+    def OnReceiveIIN(self, iin):
+        _log.debug('In MasterApplication.OnReceiveIIN')
 
-        # Overridden method
-        def OnTaskComplete(self, info):
-            _log.debug('In MasterApplication.OnTaskComplete')
+    # Overridden method
+    def OnTaskComplete(self, info):
+        _log.debug('In MasterApplication.OnTaskComplete')
 
-        # Overridden method
-        def OnTaskStart(self, type, id):
-            _log.debug('In MasterApplication.OnTaskStart')
+    # Overridden method
+    def OnTaskStart(self, type, id):
+        _log.debug('In MasterApplication.OnTaskStart')
 
 
 def collection_callback(result=None):

--- a/src/asiodnp3/ConsoleLogger.h
+++ b/src/asiodnp3/ConsoleLogger.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/ConsoleLogger.h>
 

--- a/src/asiodnp3/DNP3Manager.h
+++ b/src/asiodnp3/DNP3Manager.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/DNP3Manager.h>
 

--- a/src/asiodnp3/DatabaseConfig.h
+++ b/src/asiodnp3/DatabaseConfig.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/DatabaseConfig.h>
 

--- a/src/asiodnp3/DefaultListenCallbacks.h
+++ b/src/asiodnp3/DefaultListenCallbacks.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/DefaultListenCallbacks.h>
 

--- a/src/asiodnp3/DefaultMasterApplication.h
+++ b/src/asiodnp3/DefaultMasterApplication.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/DefaultMasterApplication.h>
 

--- a/src/asiodnp3/ErrorCodes.h
+++ b/src/asiodnp3/ErrorCodes.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/ErrorCodes.h>
 

--- a/src/asiodnp3/IChannel.h
+++ b/src/asiodnp3/IChannel.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/IChannel.h>
 

--- a/src/asiodnp3/IChannelListener.h
+++ b/src/asiodnp3/IChannelListener.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/IChannelListener.h>
 

--- a/src/asiodnp3/IListenCallbacks.h
+++ b/src/asiodnp3/IListenCallbacks.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/IListenCallbacks.h>
 

--- a/src/asiodnp3/IMaster.h
+++ b/src/asiodnp3/IMaster.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/IMaster.h>
 

--- a/src/asiodnp3/IMasterOperations.h
+++ b/src/asiodnp3/IMasterOperations.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/IMasterOperations.h>
 

--- a/src/asiodnp3/IMasterScan.h
+++ b/src/asiodnp3/IMasterScan.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/IMasterScan.h>
 

--- a/src/asiodnp3/IMasterSession.h
+++ b/src/asiodnp3/IMasterSession.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/IMasterSession.h>
 

--- a/src/asiodnp3/IOutstation.h
+++ b/src/asiodnp3/IOutstation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/IOutstation.h>
 

--- a/src/asiodnp3/ISessionAcceptor.h
+++ b/src/asiodnp3/ISessionAcceptor.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/ISessionAcceptor.h>
 

--- a/src/asiodnp3/IStack.h
+++ b/src/asiodnp3/IStack.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/IStack.h>
 

--- a/src/asiodnp3/MasterStackConfig.h
+++ b/src/asiodnp3/MasterStackConfig.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/MasterStackConfig.h>
 

--- a/src/asiodnp3/MasterTCPServer.h
+++ b/src/asiodnp3/MasterTCPServer.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/MasterTCPServer.h>
 

--- a/src/asiodnp3/OutstationStackConfig.h
+++ b/src/asiodnp3/OutstationStackConfig.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/OutstationStackConfig.h>
 

--- a/src/asiodnp3/PrintingChannelListener.h
+++ b/src/asiodnp3/PrintingChannelListener.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/PrintingChannelListener.h>
 

--- a/src/asiodnp3/PrintingCommandCallback.h
+++ b/src/asiodnp3/PrintingCommandCallback.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 #include <pybind11/functional.h>
 
 #include <asiodnp3/PrintingCommandCallback.h>

--- a/src/asiodnp3/PrintingSOEHandler.h
+++ b/src/asiodnp3/PrintingSOEHandler.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/PrintingSOEHandler.h>
 

--- a/src/asiodnp3/UpdateBuilder.h
+++ b/src/asiodnp3/UpdateBuilder.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/UpdateBuilder.h>
 

--- a/src/asiodnp3/Updates.h
+++ b/src/asiodnp3/Updates.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/Updates.h>
 

--- a/src/asiodnp3/X509Info.h
+++ b/src/asiodnp3/X509Info.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiodnp3/X509Info.h>
 

--- a/src/asiopal/ASIOSerialHelpers.h
+++ b/src/asiopal/ASIOSerialHelpers.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/ASIOSerialHelpers.h>
 

--- a/src/asiopal/ChannelRetry.h
+++ b/src/asiopal/ChannelRetry.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/ChannelRetry.h>
 

--- a/src/asiopal/Executor.h
+++ b/src/asiopal/Executor.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/Executor.h>
 

--- a/src/asiopal/IAsyncChannel.h
+++ b/src/asiopal/IAsyncChannel.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/IAsyncChannel.h>
 

--- a/src/asiopal/IChannelCallbacks.h
+++ b/src/asiopal/IChannelCallbacks.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/IChannelCallbacks.h>
 

--- a/src/asiopal/IListener.h
+++ b/src/asiopal/IListener.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/IListener.h>
 

--- a/src/asiopal/IO.h
+++ b/src/asiopal/IO.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/IO.h>
 

--- a/src/asiopal/IOpenDelayStrategy.h
+++ b/src/asiopal/IOpenDelayStrategy.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/IOpenDelayStrategy.h>
 

--- a/src/asiopal/IPEndpoint.h
+++ b/src/asiopal/IPEndpoint.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/IPEndpoint.h>
 

--- a/src/asiopal/IResourceManager.h
+++ b/src/asiopal/IResourceManager.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/IResourceManager.h>
 

--- a/src/asiopal/LoggingConnectionCondition.h
+++ b/src/asiopal/LoggingConnectionCondition.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/LoggingConnectionCondition.h>
 

--- a/src/asiopal/ResourceManager.h
+++ b/src/asiopal/ResourceManager.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/ResourceManager.h>
 

--- a/src/asiopal/SerialChannel.h
+++ b/src/asiopal/SerialChannel.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/SerialChannel.h>
 

--- a/src/asiopal/SerialTypes.h
+++ b/src/asiopal/SerialTypes.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/SerialTypes.h>
 

--- a/src/asiopal/SocketChannel.h
+++ b/src/asiopal/SocketChannel.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/SocketChannel.h>
 

--- a/src/asiopal/SocketHelpers.h
+++ b/src/asiopal/SocketHelpers.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/SocketHelpers.h>
 

--- a/src/asiopal/SteadyClock.h
+++ b/src/asiopal/SteadyClock.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/SteadyClock.h>
 

--- a/src/asiopal/Synchronized.h
+++ b/src/asiopal/Synchronized.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/Synchronized.h>
 

--- a/src/asiopal/TCPClient.h
+++ b/src/asiopal/TCPClient.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/TCPClient.h>
 

--- a/src/asiopal/TCPServer.h
+++ b/src/asiopal/TCPServer.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/TCPServer.h>
 

--- a/src/asiopal/TLSConfig.h
+++ b/src/asiopal/TLSConfig.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/TLSConfig.h>
 

--- a/src/asiopal/ThreadPool.h
+++ b/src/asiopal/ThreadPool.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/ThreadPool.h>
 

--- a/src/asiopal/TimeConversions.h
+++ b/src/asiopal/TimeConversions.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/TimeConversions.h>
 

--- a/src/asiopal/Timer.h
+++ b/src/asiopal/Timer.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/Timer.h>
 

--- a/src/asiopal/UTCTimeSource.h
+++ b/src/asiopal/UTCTimeSource.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <asiopal/UTCTimeSource.h>
 

--- a/src/opendnp3/LogLevels.h
+++ b/src/opendnp3/LogLevels.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/LogLevels.h>
 

--- a/src/opendnp3/StackStatistics.h
+++ b/src/opendnp3/StackStatistics.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/StackStatistics.h>
 

--- a/src/opendnp3/app/AnalogCommandEvent.h
+++ b/src/opendnp3/app/AnalogCommandEvent.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/AnalogCommandEvent.h>
 

--- a/src/opendnp3/app/AnalogOutput.h
+++ b/src/opendnp3/app/AnalogOutput.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/AnalogOutput.h>
 

--- a/src/opendnp3/app/AppConstants.h
+++ b/src/opendnp3/app/AppConstants.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/AppConstants.h>
 

--- a/src/opendnp3/app/BaseMeasurementTypes.h
+++ b/src/opendnp3/app/BaseMeasurementTypes.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/BaseMeasurementTypes.h>
 #include <opendnp3/gen/DoubleBit.h>

--- a/src/opendnp3/app/BinaryCommandEvent.h
+++ b/src/opendnp3/app/BinaryCommandEvent.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/BinaryCommandEvent.h>
 

--- a/src/opendnp3/app/ClassField.h
+++ b/src/opendnp3/app/ClassField.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/ClassField.h>
 

--- a/src/opendnp3/app/ControlRelayOutputBlock.h
+++ b/src/opendnp3/app/ControlRelayOutputBlock.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/ControlRelayOutputBlock.h>
 

--- a/src/opendnp3/app/DNPTime.h
+++ b/src/opendnp3/app/DNPTime.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/DNPTime.h>
 

--- a/src/opendnp3/app/EventCells.h
+++ b/src/opendnp3/app/EventCells.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/EventCells.h>
 #include <opendnp3/app/MeasurementTypeSpecs.h>

--- a/src/opendnp3/app/EventTriggers.h
+++ b/src/opendnp3/app/EventTriggers.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/EventTriggers.h>
 

--- a/src/opendnp3/app/EventType.h
+++ b/src/opendnp3/app/EventType.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/EventType.h>
 

--- a/src/opendnp3/app/Flags.h
+++ b/src/opendnp3/app/Flags.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/Flags.h>
 

--- a/src/opendnp3/app/GroupVariationID.h
+++ b/src/opendnp3/app/GroupVariationID.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/GroupVariationID.h>
 

--- a/src/opendnp3/app/ITransactable.h
+++ b/src/opendnp3/app/ITransactable.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/ITransactable.h>
 

--- a/src/opendnp3/app/Indexed.h
+++ b/src/opendnp3/app/Indexed.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/Indexed.h>
 

--- a/src/opendnp3/app/MeasurementInfo.h
+++ b/src/opendnp3/app/MeasurementInfo.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/MeasurementInfo.h>
 

--- a/src/opendnp3/app/MeasurementTypeSpecs.h
+++ b/src/opendnp3/app/MeasurementTypeSpecs.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/MeasurementTypeSpecs.h>
 

--- a/src/opendnp3/app/MeasurementTypes.h
+++ b/src/opendnp3/app/MeasurementTypes.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/MeasurementTypes.h>
 

--- a/src/opendnp3/app/OctetData.h
+++ b/src/opendnp3/app/OctetData.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/OctetData.h>
 

--- a/src/opendnp3/app/OctetString.h
+++ b/src/opendnp3/app/OctetString.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/OctetString.h>
 

--- a/src/opendnp3/app/QualityMasks.h
+++ b/src/opendnp3/app/QualityMasks.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/QualityMasks.h>
 

--- a/src/opendnp3/app/SecurityStat.h
+++ b/src/opendnp3/app/SecurityStat.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/SecurityStat.h>
 

--- a/src/opendnp3/app/parsing/ICollection.h
+++ b/src/opendnp3/app/parsing/ICollection.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/app/parsing/ICollection.h>
 

--- a/src/opendnp3/gen/AnalogOutputStatusQuality.h
+++ b/src/opendnp3/gen/AnalogOutputStatusQuality.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/AnalogOutputStatusQuality.h>
 

--- a/src/opendnp3/gen/AnalogQuality.h
+++ b/src/opendnp3/gen/AnalogQuality.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/AnalogQuality.h>
 

--- a/src/opendnp3/gen/AssignClassType.h
+++ b/src/opendnp3/gen/AssignClassType.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/AssignClassType.h>
 

--- a/src/opendnp3/gen/Attributes.h
+++ b/src/opendnp3/gen/Attributes.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/Attributes.h>
 

--- a/src/opendnp3/gen/AuthErrorCode.h
+++ b/src/opendnp3/gen/AuthErrorCode.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/AuthErrorCode.h>
 

--- a/src/opendnp3/gen/BinaryOutputStatusQuality.h
+++ b/src/opendnp3/gen/BinaryOutputStatusQuality.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/BinaryOutputStatusQuality.h>
 

--- a/src/opendnp3/gen/BinaryQuality.h
+++ b/src/opendnp3/gen/BinaryQuality.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/BinaryQuality.h>
 

--- a/src/opendnp3/gen/CertificateType.h
+++ b/src/opendnp3/gen/CertificateType.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/CertificateType.h>
 

--- a/src/opendnp3/gen/ChallengeReason.h
+++ b/src/opendnp3/gen/ChallengeReason.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/ChallengeReason.h>
 

--- a/src/opendnp3/gen/ChannelState.h
+++ b/src/opendnp3/gen/ChannelState.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/ChannelState.h>
 

--- a/src/opendnp3/gen/CommandPointState.h
+++ b/src/opendnp3/gen/CommandPointState.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/CommandPointState.h>
 

--- a/src/opendnp3/gen/CommandStatus.h
+++ b/src/opendnp3/gen/CommandStatus.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/CommandStatus.h>
 

--- a/src/opendnp3/gen/ConfigAuthMode.h
+++ b/src/opendnp3/gen/ConfigAuthMode.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/ConfigAuthMode.h>
 

--- a/src/opendnp3/gen/ControlCode.h
+++ b/src/opendnp3/gen/ControlCode.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/ControlCode.h>
 

--- a/src/opendnp3/gen/CounterQuality.h
+++ b/src/opendnp3/gen/CounterQuality.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/CounterQuality.h>
 

--- a/src/opendnp3/gen/DoubleBit.h
+++ b/src/opendnp3/gen/DoubleBit.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/DoubleBit.h>
 

--- a/src/opendnp3/gen/DoubleBitBinaryQuality.h
+++ b/src/opendnp3/gen/DoubleBitBinaryQuality.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/DoubleBitBinaryQuality.h>
 

--- a/src/opendnp3/gen/EventAnalogOutputStatusVariation.h
+++ b/src/opendnp3/gen/EventAnalogOutputStatusVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/EventAnalogOutputStatusVariation.h>
 

--- a/src/opendnp3/gen/EventAnalogVariation.h
+++ b/src/opendnp3/gen/EventAnalogVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/EventAnalogVariation.h>
 

--- a/src/opendnp3/gen/EventBinaryOutputStatusVariation.h
+++ b/src/opendnp3/gen/EventBinaryOutputStatusVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/EventBinaryOutputStatusVariation.h>
 

--- a/src/opendnp3/gen/EventBinaryVariation.h
+++ b/src/opendnp3/gen/EventBinaryVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/EventBinaryVariation.h>
 

--- a/src/opendnp3/gen/EventCounterVariation.h
+++ b/src/opendnp3/gen/EventCounterVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/EventCounterVariation.h>
 

--- a/src/opendnp3/gen/EventDoubleBinaryVariation.h
+++ b/src/opendnp3/gen/EventDoubleBinaryVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/EventDoubleBinaryVariation.h>
 

--- a/src/opendnp3/gen/EventFrozenCounterVariation.h
+++ b/src/opendnp3/gen/EventFrozenCounterVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/EventFrozenCounterVariation.h>
 

--- a/src/opendnp3/gen/EventMode.h
+++ b/src/opendnp3/gen/EventMode.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/EventMode.h>
 

--- a/src/opendnp3/gen/EventSecurityStatVariation.h
+++ b/src/opendnp3/gen/EventSecurityStatVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/EventSecurityStatVariation.h>
 

--- a/src/opendnp3/gen/FlagsType.h
+++ b/src/opendnp3/gen/FlagsType.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/FlagsType.h>
 

--- a/src/opendnp3/gen/FlowControl.h
+++ b/src/opendnp3/gen/FlowControl.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/FlowControl.h>
 

--- a/src/opendnp3/gen/FrozenCounterQuality.h
+++ b/src/opendnp3/gen/FrozenCounterQuality.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/FrozenCounterQuality.h>
 

--- a/src/opendnp3/gen/FunctionCode.h
+++ b/src/opendnp3/gen/FunctionCode.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/FunctionCode.h>
 

--- a/src/opendnp3/gen/GroupVariation.h
+++ b/src/opendnp3/gen/GroupVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/GroupVariation.h>
 

--- a/src/opendnp3/gen/HMACType.h
+++ b/src/opendnp3/gen/HMACType.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/HMACType.h>
 

--- a/src/opendnp3/gen/IndexMode.h
+++ b/src/opendnp3/gen/IndexMode.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/IndexMode.h>
 

--- a/src/opendnp3/gen/IntervalUnits.h
+++ b/src/opendnp3/gen/IntervalUnits.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/IntervalUnits.h>
 

--- a/src/opendnp3/gen/KeyChangeMethod.h
+++ b/src/opendnp3/gen/KeyChangeMethod.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/KeyChangeMethod.h>
 

--- a/src/opendnp3/gen/KeyStatus.h
+++ b/src/opendnp3/gen/KeyStatus.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/KeyStatus.h>
 

--- a/src/opendnp3/gen/KeyWrapAlgorithm.h
+++ b/src/opendnp3/gen/KeyWrapAlgorithm.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/KeyWrapAlgorithm.h>
 

--- a/src/opendnp3/gen/LinkFunction.h
+++ b/src/opendnp3/gen/LinkFunction.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/LinkFunction.h>
 

--- a/src/opendnp3/gen/LinkStatus.h
+++ b/src/opendnp3/gen/LinkStatus.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/LinkStatus.h>
 

--- a/src/opendnp3/gen/MasterTaskType.h
+++ b/src/opendnp3/gen/MasterTaskType.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/MasterTaskType.h>
 

--- a/src/opendnp3/gen/OperateType.h
+++ b/src/opendnp3/gen/OperateType.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/OperateType.h>
 

--- a/src/opendnp3/gen/Parity.h
+++ b/src/opendnp3/gen/Parity.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/Parity.h>
 

--- a/src/opendnp3/gen/PointClass.h
+++ b/src/opendnp3/gen/PointClass.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/PointClass.h>
 

--- a/src/opendnp3/gen/QualifierCode.h
+++ b/src/opendnp3/gen/QualifierCode.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/QualifierCode.h>
 

--- a/src/opendnp3/gen/RestartMode.h
+++ b/src/opendnp3/gen/RestartMode.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/RestartMode.h>
 

--- a/src/opendnp3/gen/RestartType.h
+++ b/src/opendnp3/gen/RestartType.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/RestartType.h>
 

--- a/src/opendnp3/gen/SecurityStatIndex.h
+++ b/src/opendnp3/gen/SecurityStatIndex.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/SecurityStatIndex.h>
 

--- a/src/opendnp3/gen/StaticAnalogOutputStatusVariation.h
+++ b/src/opendnp3/gen/StaticAnalogOutputStatusVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StaticAnalogOutputStatusVariation.h>
 

--- a/src/opendnp3/gen/StaticAnalogVariation.h
+++ b/src/opendnp3/gen/StaticAnalogVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StaticAnalogVariation.h>
 

--- a/src/opendnp3/gen/StaticBinaryOutputStatusVariation.h
+++ b/src/opendnp3/gen/StaticBinaryOutputStatusVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StaticBinaryOutputStatusVariation.h>
 

--- a/src/opendnp3/gen/StaticBinaryVariation.h
+++ b/src/opendnp3/gen/StaticBinaryVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StaticBinaryVariation.h>
 

--- a/src/opendnp3/gen/StaticCounterVariation.h
+++ b/src/opendnp3/gen/StaticCounterVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StaticCounterVariation.h>
 

--- a/src/opendnp3/gen/StaticDoubleBinaryVariation.h
+++ b/src/opendnp3/gen/StaticDoubleBinaryVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StaticDoubleBinaryVariation.h>
 

--- a/src/opendnp3/gen/StaticFrozenCounterVariation.h
+++ b/src/opendnp3/gen/StaticFrozenCounterVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StaticFrozenCounterVariation.h>
 

--- a/src/opendnp3/gen/StaticSecurityStatVariation.h
+++ b/src/opendnp3/gen/StaticSecurityStatVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StaticSecurityStatVariation.h>
 

--- a/src/opendnp3/gen/StaticTimeAndIntervalVariation.h
+++ b/src/opendnp3/gen/StaticTimeAndIntervalVariation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StaticTimeAndIntervalVariation.h>
 

--- a/src/opendnp3/gen/StaticTypeBitmask.h
+++ b/src/opendnp3/gen/StaticTypeBitmask.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StaticTypeBitmask.h>
 

--- a/src/opendnp3/gen/StopBits.h
+++ b/src/opendnp3/gen/StopBits.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/StopBits.h>
 

--- a/src/opendnp3/gen/TaskCompletion.h
+++ b/src/opendnp3/gen/TaskCompletion.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/TaskCompletion.h>
 

--- a/src/opendnp3/gen/TimeSyncMode.h
+++ b/src/opendnp3/gen/TimeSyncMode.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/TimeSyncMode.h>
 

--- a/src/opendnp3/gen/TimestampMode.h
+++ b/src/opendnp3/gen/TimestampMode.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/TimestampMode.h>
 

--- a/src/opendnp3/gen/UserOperation.h
+++ b/src/opendnp3/gen/UserOperation.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/UserOperation.h>
 

--- a/src/opendnp3/gen/UserRole.h
+++ b/src/opendnp3/gen/UserRole.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/gen/UserRole.h>
 

--- a/src/opendnp3/link/ILinkListener.h
+++ b/src/opendnp3/link/ILinkListener.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/link/ILinkListener.h>
 

--- a/src/opendnp3/link/LinkConfig.h
+++ b/src/opendnp3/link/LinkConfig.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/link/LinkConfig.h>
 

--- a/src/opendnp3/link/LinkHeaderFields.h
+++ b/src/opendnp3/link/LinkHeaderFields.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/link/LinkHeaderFields.h>
 

--- a/src/opendnp3/link/LinkStatistics.h
+++ b/src/opendnp3/link/LinkStatistics.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/link/LinkStatistics.h>
 

--- a/src/opendnp3/master/CommandCallbackT.h
+++ b/src/opendnp3/master/CommandCallbackT.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/CommandCallbackT.h>
 

--- a/src/opendnp3/master/CommandPointResult.h
+++ b/src/opendnp3/master/CommandPointResult.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/CommandPointResult.h>
 

--- a/src/opendnp3/master/CommandSet.h
+++ b/src/opendnp3/master/CommandSet.h
@@ -31,7 +31,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/functional.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/CommandSet.h>
 

--- a/src/opendnp3/master/HeaderInfo.h
+++ b/src/opendnp3/master/HeaderInfo.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/HeaderInfo.h>
 

--- a/src/opendnp3/master/HeaderTypes.h
+++ b/src/opendnp3/master/HeaderTypes.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/HeaderTypes.h>
 

--- a/src/opendnp3/master/ICommandCollection.h
+++ b/src/opendnp3/master/ICommandCollection.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/ICommandCollection.h>
 

--- a/src/opendnp3/master/ICommandProcessor.h
+++ b/src/opendnp3/master/ICommandProcessor.h
@@ -30,7 +30,7 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/functional.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/ICommandProcessor.h>
 

--- a/src/opendnp3/master/ICommandTaskResult.h
+++ b/src/opendnp3/master/ICommandTaskResult.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/ICommandTaskResult.h>
 

--- a/src/opendnp3/master/IMasterApplication.h
+++ b/src/opendnp3/master/IMasterApplication.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/IMasterApplication.h>
 

--- a/src/opendnp3/master/ISOEHandler.h
+++ b/src/opendnp3/master/ISOEHandler.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/ISOEHandler.h>
 

--- a/src/opendnp3/master/ITaskCallback.h
+++ b/src/opendnp3/master/ITaskCallback.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/ITaskCallback.h>
 

--- a/src/opendnp3/master/MasterParams.h
+++ b/src/opendnp3/master/MasterParams.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/MasterParams.h>
 

--- a/src/opendnp3/master/RestartOperationResult.h
+++ b/src/opendnp3/master/RestartOperationResult.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 #include <iostream>
 
 #include <opendnp3/master/RestartOperationResult.h>

--- a/src/opendnp3/master/TaskConfig.h
+++ b/src/opendnp3/master/TaskConfig.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/TaskConfig.h>
 

--- a/src/opendnp3/master/TaskId.h
+++ b/src/opendnp3/master/TaskId.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/TaskId.h>
 

--- a/src/opendnp3/master/TaskInfo.h
+++ b/src/opendnp3/master/TaskInfo.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/master/TaskInfo.h>
 

--- a/src/opendnp3/outstation/ApplicationIIN.h
+++ b/src/opendnp3/outstation/ApplicationIIN.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/ApplicationIIN.h>
 

--- a/src/opendnp3/outstation/Cell.h
+++ b/src/opendnp3/outstation/Cell.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/Cell.h>
 

--- a/src/opendnp3/outstation/DatabaseSizes.h
+++ b/src/opendnp3/outstation/DatabaseSizes.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/DatabaseSizes.h>
 

--- a/src/opendnp3/outstation/EventBufferConfig.h
+++ b/src/opendnp3/outstation/EventBufferConfig.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/EventBufferConfig.h>
 

--- a/src/opendnp3/outstation/ICommandHandler.h
+++ b/src/opendnp3/outstation/ICommandHandler.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 #include <opendnp3/outstation/ICommandHandler.h>
 
 #include "opendnp3/app/ITransactable.h"

--- a/src/opendnp3/outstation/IOutstationApplication.h
+++ b/src/opendnp3/outstation/IOutstationApplication.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/IOutstationApplication.h>
 

--- a/src/opendnp3/outstation/IUpdateHandler.h
+++ b/src/opendnp3/outstation/IUpdateHandler.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/IUpdateHandler.h>
 

--- a/src/opendnp3/outstation/MeasurementConfig.h
+++ b/src/opendnp3/outstation/MeasurementConfig.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/MeasurementConfig.h>
 

--- a/src/opendnp3/outstation/OutstationConfig.h
+++ b/src/opendnp3/outstation/OutstationConfig.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/OutstationConfig.h>
 

--- a/src/opendnp3/outstation/OutstationParams.h
+++ b/src/opendnp3/outstation/OutstationParams.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/OutstationParams.h>
 

--- a/src/opendnp3/outstation/SimpleCommandHandler.h
+++ b/src/opendnp3/outstation/SimpleCommandHandler.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/SimpleCommandHandler.h>
 

--- a/src/opendnp3/outstation/StaticTypeBitfield.h
+++ b/src/opendnp3/outstation/StaticTypeBitfield.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <opendnp3/outstation/StaticTypeBitfield.h>
 

--- a/src/openpal/Configure.h
+++ b/src/openpal/Configure.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/Configure.h>
 

--- a/src/openpal/channel/IPhysicalLayer.h
+++ b/src/openpal/channel/IPhysicalLayer.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/channel/IPhysicalLayer.h>
 

--- a/src/openpal/channel/IPhysicalLayerCallbacks.h
+++ b/src/openpal/channel/IPhysicalLayerCallbacks.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/channel/IPhysicalLayerCallbacks.h>
 

--- a/src/openpal/container/Array.h
+++ b/src/openpal/container/Array.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/Array.h>
 #include <pybind11/operators.h>

--- a/src/openpal/container/ArrayView.h
+++ b/src/openpal/container/ArrayView.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/ArrayView.h>
 

--- a/src/openpal/container/Buffer.h
+++ b/src/openpal/container/Buffer.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/Buffer.h>
 

--- a/src/openpal/container/HasSize.h
+++ b/src/openpal/container/HasSize.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/HasSize.h>
 

--- a/src/openpal/container/LinkedList.h
+++ b/src/openpal/container/LinkedList.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/LinkedList.h>
 

--- a/src/openpal/container/Pair.h
+++ b/src/openpal/container/Pair.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/Pair.h>
 

--- a/src/openpal/container/Queue.h
+++ b/src/openpal/container/Queue.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/Queue.h>
 

--- a/src/openpal/container/RSlice.h
+++ b/src/openpal/container/RSlice.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/RSlice.h>
 

--- a/src/openpal/container/RingBuffer.h
+++ b/src/openpal/container/RingBuffer.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/RingBuffer.h>
 

--- a/src/openpal/container/SecureBuffer.h
+++ b/src/openpal/container/SecureBuffer.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/SecureBuffer.h>
 

--- a/src/openpal/container/Settable.h
+++ b/src/openpal/container/Settable.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/Settable.h>
 

--- a/src/openpal/container/StaticBuffer.h
+++ b/src/openpal/container/StaticBuffer.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/StaticBuffer.h>
 

--- a/src/openpal/container/WSlice.h
+++ b/src/openpal/container/WSlice.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/container/WSlice.h>
 

--- a/src/openpal/executor/IExecutor.h
+++ b/src/openpal/executor/IExecutor.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/executor/IExecutor.h>
 

--- a/src/openpal/executor/IMonotonicTimeSource.h
+++ b/src/openpal/executor/IMonotonicTimeSource.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/executor/IMonotonicTimeSource.h>
 

--- a/src/openpal/executor/ITimer.h
+++ b/src/openpal/executor/ITimer.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/executor/ITimer.h>
 

--- a/src/openpal/executor/IUTCTimeSource.h
+++ b/src/openpal/executor/IUTCTimeSource.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/executor/IUTCTimeSource.h>
 

--- a/src/openpal/executor/MonotonicTimestamp.h
+++ b/src/openpal/executor/MonotonicTimestamp.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/executor/MonotonicTimestamp.h>
 

--- a/src/openpal/executor/TimeDuration.h
+++ b/src/openpal/executor/TimeDuration.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/executor/TimeDuration.h>
 

--- a/src/openpal/executor/TimerRef.h
+++ b/src/openpal/executor/TimerRef.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/executor/TimerRef.h>
 

--- a/src/openpal/executor/UTCTimestamp.h
+++ b/src/openpal/executor/UTCTimestamp.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/executor/UTCTimestamp.h>
 

--- a/src/openpal/logging/ILogHandler.h
+++ b/src/openpal/logging/ILogHandler.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/logging/ILogHandler.h>
 

--- a/src/openpal/logging/LogEntry.h
+++ b/src/openpal/logging/LogEntry.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/logging/LogEntry.h>
 

--- a/src/openpal/logging/LogFilters.h
+++ b/src/openpal/logging/LogFilters.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/logging/LogFilters.h>
 

--- a/src/openpal/logging/LogLevels.h
+++ b/src/openpal/logging/LogLevels.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/logging/LogLevels.h>
 

--- a/src/openpal/logging/Logger.h
+++ b/src/openpal/logging/Logger.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/logging/Logger.h>
 

--- a/src/openpal/logging/StringFormatting.h
+++ b/src/openpal/logging/StringFormatting.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/logging/StringFormatting.h>
 

--- a/src/openpal/serialization/DoubleFloat.h
+++ b/src/openpal/serialization/DoubleFloat.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/serialization/DoubleFloat.h>
 

--- a/src/openpal/serialization/FloatByteOrder.h
+++ b/src/openpal/serialization/FloatByteOrder.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/serialization/FloatByteOrder.h>
 

--- a/src/openpal/serialization/Format.h
+++ b/src/openpal/serialization/Format.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/serialization/Format.h>
 

--- a/src/openpal/serialization/Parse.h
+++ b/src/openpal/serialization/Parse.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/serialization/Parse.h>
 

--- a/src/openpal/serialization/Serialization.h
+++ b/src/openpal/serialization/Serialization.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/serialization/Serialization.h>
 

--- a/src/openpal/serialization/SerializationTemplatesLE.h
+++ b/src/openpal/serialization/SerializationTemplatesLE.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/serialization/SerializationTemplatesLE.h>
 

--- a/src/openpal/serialization/Serializer.h
+++ b/src/openpal/serialization/Serializer.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/serialization/Serializer.h>
 

--- a/src/openpal/serialization/SingleFloat.h
+++ b/src/openpal/serialization/SingleFloat.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/serialization/SingleFloat.h>
 

--- a/src/openpal/util/Comparisons.h
+++ b/src/openpal/util/Comparisons.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/util/Comparisons.h>
 

--- a/src/openpal/util/Finally.h
+++ b/src/openpal/util/Finally.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/util/Finally.h>
 

--- a/src/openpal/util/Limits.h
+++ b/src/openpal/util/Limits.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/util/Limits.h>
 

--- a/src/openpal/util/SequenceNum.h
+++ b/src/openpal/util/SequenceNum.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/util/SequenceNum.h>
 

--- a/src/openpal/util/ToHex.h
+++ b/src/openpal/util/ToHex.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/util/ToHex.h>
 

--- a/src/openpal/util/Uncopyable.h
+++ b/src/openpal/util/Uncopyable.h
@@ -29,7 +29,7 @@
  */
 
 #include <pybind11/pybind11.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 
 #include <openpal/util/Uncopyable.h>
 


### PR DESCRIPTION
The methods weren't properly being overridden because they were in the __init__ function instead of the class.

This also includes a different fix, partly because I'm bad at git, hopefully the other fix will also be accepted as well.